### PR TITLE
Move inactive maintainers to emeritus status

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,8 +6,12 @@ Maintainers
 | Name | GitHub | Chat | email
 |------|--------|------|----------------------
 | Vipin Bharathan | [vipinsun](https://github.com/vipinsun) | VipinB  | 
-| Matias Salimbene | [salimbene](https://github.com/salimbene) | matisalimba  | 
+
+
+**Emeritus Maintainers**
+
+| Name | GitHub | Chat | email
+|------|--------|------|----------------------
 | Kamlesh Nagware | [knagware9](https://github.com/knagware9) | knagware9  | 
+| Matias Salimbene | [salimbene](https://github.com/salimbene) | matisalimba  | 
 | Sandy Aggarwal | [sandywalls](https://github.com/sandywalls) |  |  
-
-


### PR DESCRIPTION
The TOC approved a requirement that maintainers
that have not been active in over three to six
months be move to emeritus status.

These maintainers have not been active in over
one year.

https://github.com/hyperledger/toc/issues/32

Signed-off-by: Ry Jones <ry@linux.com>